### PR TITLE
fix: dependabot.yml remove reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,8 @@ updates:
       interval: 'daily'
     allow:
       - dependency-type: 'direct'
-    reviewers:
-      - 'VKCOM/vk-sec'
 
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'daily'
-    reviewers:
-      - 'VKCOM/vk-sec'


### PR DESCRIPTION
https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

